### PR TITLE
Added __hash__ to asset to allow for Asset as a dict key

### DIFF
--- a/pactsdk/asset.py
+++ b/pactsdk/asset.py
@@ -153,3 +153,10 @@ class Asset:
         if not isinstance(other_asset, Asset):
             return False
         return self.index == other_asset.index
+
+    def __hash__(self) -> int:
+        """Returns an int which is the asset_id of the :class:`Asset` current object
+        :return: asset_id
+        :rtype: int
+        """
+        return self.asset_id


### PR DESCRIPTION
Added "hash" to the asset class to allow for it to be used as a key in dicts and other usages.
For example you can now use the Asset Object below
```
from algosdk.v2client.algod import AlgodClient

import pactsdk

algod = AlgodClient("<token>", "<url>")
pact = pactsdk.PactClient(algod)

algo = pact.fetch_asset(0)
usdc = pact.fetch_asset(31566704)
assets = {
    algo : "Some Asset",
    usdc : "Some Asset 2"
}
```